### PR TITLE
Cargo.toml: add `uudoc` as feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ build = "build.rs"
 
 [features]
 default = ["feat_common_core"]
+uudoc = []
 
 feat_common_core = [
   "login",


### PR DESCRIPTION
This PR adds `uudoc` as a feature to `Cargo.toml` to fix the warning `warning: invalid feature uudoc in required-features of target uudoc: uudoc is not present in [features] section`.