### PR TITLE
Some small fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # login (uutils)
 # * see the repository LICENSE, README, and CONTRIBUTING files for more information
 
-# spell-checker:ignore (libs) bigdecimal datetime fundu gethostid kqueue libselinux mangen memmap procfs uuhelp
+# spell-checker:ignore (libs) mangen procfs
 
 [package]
 name = "login"

--- a/build.rs
+++ b/build.rs
@@ -11,13 +11,12 @@ use std::io::Write;
 use std::path::Path;
 
 pub fn main() {
+    const ENV_FEATURE_PREFIX: &str = "CARGO_FEATURE_";
+    const FEATURE_PREFIX: &str = "feat_";
+
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=build={profile:?}");
     }
-
-    const ENV_FEATURE_PREFIX: &str = "CARGO_FEATURE_";
-    const FEATURE_PREFIX: &str = "feat_";
-    const OVERRIDE_PREFIX: &str = "uu_";
 
     let out_dir = env::var("OUT_DIR").unwrap();
 
@@ -54,45 +53,7 @@ pub fn main() {
     let mut phf_map = phf_codegen::OrderedMap::<&str>::new();
     for krate in &crates {
         let map_value = format!("({krate}::uumain, {krate}::uu_app)");
-        match krate.as_ref() {
-            // 'test' is named uu_test to avoid collision with rust core crate 'test'.
-            // It can also be invoked by name '[' for the '[ expr ] syntax'.
-            "uu_test" => {
-                phf_map.entry("test", &map_value);
-                phf_map.entry("[", &map_value);
-            }
-            k if k.starts_with(OVERRIDE_PREFIX) => {
-                phf_map.entry(&k[OVERRIDE_PREFIX.len()..], &map_value);
-            }
-            "false" | "true" => {
-                phf_map.entry(krate, &format!("(r#{krate}::uumain, r#{krate}::uu_app)"));
-            }
-            "hashsum" => {
-                phf_map.entry(krate, &format!("({krate}::uumain, {krate}::uu_app_custom)"));
-
-                let map_value = format!("({krate}::uumain, {krate}::uu_app_common)");
-                let map_value_bits = format!("({krate}::uumain, {krate}::uu_app_bits)");
-                let map_value_b3sum = format!("({krate}::uumain, {krate}::uu_app_b3sum)");
-                phf_map.entry("md5sum", &map_value);
-                phf_map.entry("sha1sum", &map_value);
-                phf_map.entry("sha224sum", &map_value);
-                phf_map.entry("sha256sum", &map_value);
-                phf_map.entry("sha384sum", &map_value);
-                phf_map.entry("sha512sum", &map_value);
-                phf_map.entry("sha3sum", &map_value_bits);
-                phf_map.entry("sha3-224sum", &map_value);
-                phf_map.entry("sha3-256sum", &map_value);
-                phf_map.entry("sha3-384sum", &map_value);
-                phf_map.entry("sha3-512sum", &map_value);
-                phf_map.entry("shake128sum", &map_value_bits);
-                phf_map.entry("shake256sum", &map_value_bits);
-                phf_map.entry("b2sum", &map_value);
-                phf_map.entry("b3sum", &map_value_b3sum);
-            }
-            _ => {
-                phf_map.entry(krate, &map_value);
-            }
-        }
+        phf_map.entry(krate, &map_value);
     }
     write!(mf, "{}", phf_map.build()).unwrap();
     mf.write_all(b"\n}\n").unwrap();

--- a/src/bin/login.rs
+++ b/src/bin/login.rs
@@ -85,9 +85,8 @@ fn main() {
             process::exit(1);
         }
 
-        let util = match util_os.to_str() {
-            Some(util) => util,
-            None => not_found(&util_os),
+        let Some(util) = util_os.to_str() else {
+            not_found(&util_os)
         };
 
         if util == "completion" {
@@ -106,9 +105,8 @@ fn main() {
                 if util == "--help" || util == "-h" {
                     // see if they want help on a specific util
                     if let Some(util_os) = args.next() {
-                        let util = match util_os.to_str() {
-                            Some(util) => util,
-                            None => not_found(&util_os),
+                        let Some(util) = util_os.to_str() else {
+                            not_found(&util_os)
                         };
 
                         match utils.get(util) {


### PR DESCRIPTION
This PR does three things:
* removes coreutils stuff from `build.rs`
* cleans up `spell-checker:ignore` entries in `Cargo.toml`
* uses `let`/`else` instead of `match` in `bin/login.rs`