### PR TITLE
Rename multi-call binary from `login` to `shadow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.0.1"
 authors = ["uutils developers"]
 license = "MIT"
 description = "login ~ implemented as universal (cross-platform) utils, written in Rust"
-default-run = "login"
+default-run = "shadow"
 
 homepage = "https://github.com/uutils/login"
 repository = "https://github.com/uutils/login"
@@ -77,8 +77,8 @@ phf_codegen = { workspace = true }
 
 
 [[bin]]
-name = "login"
-path = "src/bin/login.rs"
+name = "shadow"
+path = "src/bin/shadow.rs"
 
 [[bin]]
 name = "uudoc"

--- a/src/bin/shadow.rs
+++ b/src/bin/shadow.rs
@@ -140,7 +140,7 @@ fn gen_completions<T: uucore::Args>(
     args: impl Iterator<Item = OsString>,
     util_map: &UtilityMap<T>,
 ) -> ! {
-    let all_utilities: Vec<_> = std::iter::once("login")
+    let all_utilities: Vec<_> = std::iter::once("shadow")
         .chain(util_map.keys().copied())
         .collect();
 
@@ -161,8 +161,8 @@ fn gen_completions<T: uucore::Args>(
     let utility = matches.get_one::<String>("utility").unwrap();
     let shell = *matches.get_one::<Shell>("shell").unwrap();
 
-    let mut command = if utility == "login" {
-        gen_login_app(util_map)
+    let mut command = if utility == "shadow" {
+        gen_shadow_app(util_map)
     } else {
         util_map.get(utility).unwrap().1()
     };
@@ -178,7 +178,7 @@ fn gen_manpage<T: uucore::Args>(
     args: impl Iterator<Item = OsString>,
     util_map: &UtilityMap<T>,
 ) -> ! {
-    let all_utilities: Vec<_> = std::iter::once("login")
+    let all_utilities: Vec<_> = std::iter::once("shadow")
         .chain(util_map.keys().copied())
         .collect();
 
@@ -193,8 +193,8 @@ fn gen_manpage<T: uucore::Args>(
 
     let utility = matches.get_one::<String>("utility").unwrap();
 
-    let command = if utility == "login" {
-        gen_login_app(util_map)
+    let command = if utility == "shadow" {
+        gen_shadow_app(util_map)
     } else {
         util_map.get(utility).unwrap().1()
     };
@@ -206,8 +206,8 @@ fn gen_manpage<T: uucore::Args>(
     process::exit(0);
 }
 
-fn gen_login_app<T: uucore::Args>(util_map: &UtilityMap<T>) -> Command {
-    let mut command = Command::new("login");
+fn gen_shadow_app<T: uucore::Args>(util_map: &UtilityMap<T>) -> Command {
+    let mut command = Command::new("shadow");
     for (name, (_, sub_app)) in util_map {
         // Recreate a small subcommand with only the relevant info
         // (name & short description)


### PR DESCRIPTION
This PR renames the multi-call binary from `login` to `shadow` in order to distinguish between the multi-call binary and the `login` util.

Not sure about the name `shadow`, maybe `shadow-utils` would be better?