### PR TITLE
Cargo.toml: remove `sysinfo`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,38 +30,38 @@ feat_common_core = [
 ]
 
 [workspace.dependencies]
-uucore = "0.0.30"
 clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5.2"
 clap_mangen = "0.2.20"
-regex = "1.10.4"
 libc = "0.2.154"
 phf = "0.11.2"
 phf_codegen = "0.11.2"
-textwrap = { version = "0.16.1", features = ["terminal_size"] }
-xattr = "1.3.1"
-tempfile = "3.10.1"
 rand = { version = "0.9.0", features = ["small_rng"] }
+regex = "1.10.4"
+tempfile = "3.10.1"
+textwrap = { version = "0.16.1", features = ["terminal_size"] }
 utmpx = "0.2"
+uucore = "0.0.30"
+xattr = "1.3.1"
 
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
-uucore = { workspace = true }
 phf = { workspace = true }
 textwrap = { workspace = true }
+uucore = { workspace = true }
 
 
 #
 login = { optional = true, version = "0.0.1", package = "uu_login", path = "src/uu/login" }
 
 [dev-dependencies]
+libc = { workspace = true }
 pretty_assertions = "1.4.0"
+rand = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
-libc = { workspace = true }
-rand = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5.2"
 clap_mangen = "0.2.20"
 regex = "1.10.4"
-sysinfo = "0.35.0"
 libc = "0.2.154"
 phf = "0.11.2"
 phf_codegen = "0.11.2"


### PR DESCRIPTION
This PR removes the unused `sysinfo` dependency. It also sorts the dependencies alphabetically.